### PR TITLE
fix: start:dev fails to start locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "rm -rf dist && tsc",
     "watch": "tsc -w & nodemon",
     "start": "node dist/index.js",
-    "start:dev": "NODE_ENV=local npm run build && rover supergraph compose --config ./local-supergraph-config.yaml > local-supergraph.graphql --elv2-license accept && NODE_ENV=development AWS_XRAY_LOG_LEVEL=silent AWS_XRAY_CONTEXT_MISSING=LOG_ERROR npm run watch",
+    "start:dev": "NODE_ENV=local npm run build && rover supergraph compose --config ./local-supergraph-config.yaml > local-supergraph.graphql --elv2-license accept && NODE_ENV=local AWS_XRAY_LOG_LEVEL=silent AWS_XRAY_CONTEXT_MISSING=LOG_ERROR npm run watch",
     "test-ci": "npm test",
     "test:watch": "npm test -- --watchAll",
     "test": "jest",


### PR DESCRIPTION
## Goal
Fix an error during local development:

> Error: When a manual configuration is not provided, gateway requires an Apollo configuration.

Local development should use `NODE_END=local` since https://github.com/Pocket/admin-api/pull/361

## How to know this working

`docker compose up`, `npm ci`, `npm run start:dev`