### PR TITLE
fix: specify TF workspace when terraform init

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -47,7 +47,7 @@ phases:
       # synthesize the js into terraform json with the proper node environment
       - 'if [ "$GIT_BRANCH" = "$DEV_BRANCH" ]; then NODE_ENV=development npm run synth; else npm run synth; fi'
       - cd cdktf.out/stacks/admin-api
-      - terraform init
+      - 'if [ "$GIT_BRANCH" = "$DEV_BRANCH" ]; then TF_WORKSPACE=$TF_DEV_WORKSPACE terraform init; else terraform init; fi'
   build:
     run-as: circleci
     commands:


### PR DESCRIPTION
## Goal

In the dev env, when `terraform init`, resulted in the error:
```
The currently selected workspace (Prod) does not exist.
  This is expected behavior when the selected workspace did not have an
  existing non-empty state. Please enter a number to select a workspace:
  1. default
  2. Dev
  Enter a value: ╷
│ Error: Failed to select workspace: EOF
```

Fix: specifying TF workspace for dev env.
