### PR TITLE
chore(HNT-2502): stop accepting CognitoAdmin-Prod tokens

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -22,19 +22,6 @@ const config = {
     environment: process.env.NODE_ENV || 'development',
   },
   auth: {
-    //Cognito is deprecated in favor of Mozilla Auth Proxy, but we still need to support it
-    //Mozilla Auth Proxy supports a larger number of user groups for a user.
-    cognito: {
-      jwtIssuer:
-        // COGNITO_JWT_ISSUER is not set in this repo (or anywhere?)
-        process.env.COGNITO_JWT_ISSUER ||
-        'cognito-idp.us-east-1.amazonaws.com/us-east-1_1alKls4qw',
-      // COGNITO_KIDS is not set in this repo (or anywhere?)
-      kids: process.env.COGNITO_KIDS?.split(',') || [
-        'kze4M0CiXoDO7Qkpig1oH0F6OInzZg6ugk0PyojOlzc=',
-        '4w35mrh4EBECpjJnyIjdQ60yjh3xeI1m0VF1H/z0T/c=',
-      ],
-    },
     mozillaAuthProxy: {
       jwtIssuer:
         // MOZILLA_AUTH_PROXY_JWT_ISSUER is not set in this repo (or anywhere?)

--- a/src/jwtUtils.spec.ts
+++ b/src/jwtUtils.spec.ts
@@ -55,26 +55,6 @@ describe('jwtUtils', () => {
       process.env.NODE_ENV = originalNodeEnv;
     });
 
-    const cognitoJwks = {
-      keys: [
-        {
-          alg: 'RS256',
-          e: 'AQAB',
-          kid: 'kze4M0CiXoDO7Qkpig1oH0F6OInzZg6ugk0PyojOlzc=',
-          kty: 'RSA',
-          n: 'uXk44uWZ2tx',
-          use: 'sig',
-        },
-        {
-          alg: 'RS256',
-          e: 'AQAB',
-          kid: '4w35mrh4EBECpjJnyIjdQ60yjh3xeI1m0VF1H/z0T/c=',
-          kty: 'RSA',
-          n: '7LjXOvCWl6Y',
-          use: 'sig',
-        },
-      ],
-    };
     const mozillaAuthProxyJwks = {
       keys: [
         {
@@ -213,15 +193,13 @@ describe('jwtUtils', () => {
     };
 
     it.each(['production', 'development'])(
-      `should get keys from cognito and pocket in %s`,
+      `should get keys from mozilla auth proxy and pocket in %s`,
       async (env) => {
         // Override NODE_ENV and dynamically import getSigningKeysFromServer to re-compute the config in the given env.
         process.env.NODE_ENV = env;
         const { getSigningKeysFromServer } = await import('./jwtUtils');
 
         const expectedKids = [
-          'kze4M0CiXoDO7Qkpig1oH0F6OInzZg6ugk0PyojOlzc=',
-          '4w35mrh4EBECpjJnyIjdQ60yjh3xeI1m0VF1H/z0T/c=',
           'OR8erz5A8/hCkVdHczk879k2zUQXoAke9p8TQXsgKLQ=',
           'QtBbT/twDz6JmT99PQkAOB+QBhG4eJvxk8pOr7YzfWU=',
           ...(env === 'development'
@@ -229,10 +207,6 @@ describe('jwtUtils', () => {
             : ['CURMIG', 'CORPSL', 'SEMGRL', 'MLMFLO', 'PROTRL', 'HNTCPP']),
         ];
 
-        const cognitoMock = nock('https://' + config.auth.cognito.jwtIssuer)
-          .persist()
-          .get('/.well-known/jwks.json')
-          .reply(200, cognitoJwks);
         const mozillaAuthProxyMock = nock(
           'https://' + config.auth.mozillaAuthProxy.jwtIssuer,
         )
@@ -248,7 +222,6 @@ describe('jwtUtils', () => {
 
         expect(Object.keys(keys)).toEqual(expectedKids);
 
-        cognitoMock.persist(false);
         mozillaAuthProxyMock.persist(false);
       },
     );

--- a/src/jwtUtils.ts
+++ b/src/jwtUtils.ts
@@ -130,17 +130,6 @@ function getJwksClient(jwksUri: string) {
 }
 
 /**
- * Get JWKs from cognito
- */
-function getCognitoJwks() {
-  const jwksUri = `https://${config.auth.cognito.jwtIssuer}/.well-known/jwks.json`;
-  const client = getJwksClient(jwksUri);
-  return config.auth.cognito.kids.map((kid: string) =>
-    client.getSigningKeyAsync(kid),
-  );
-}
-
-/**
  * Get JWKs from mozilla auth proxy
  */
 function getMozillaAuthProxyJwks() {
@@ -170,7 +159,6 @@ export const getSigningKeysFromServer = async (): Promise<
   Record<string, string>
 > => {
   const keys = await Promise.all([
-    ...getCognitoJwks(),
     ...getMozillaAuthProxyJwks(),
     ...getPocketJwks(),
   ]);


### PR DESCRIPTION
## Goal

Stop accepting JWTs from the deprecated `CognitoAdmin-Prod` pool (`us-east-1_1alKls4qw`). Only `MozillaAuthProxy-Prod` and the Pocket JWK set remain. Less auth-flow complexity, less attack surface.

## Investigation

Admin-api started accepting both pools in #150 (2022-06) so front-ends could migrate gradually. [curation-admin-tools#840](https://github.com/Pocket/curation-admin-tools/pull/840) (2024-07) was the last migration. Nothing active remains on the legacy pool:

- No user-record modifications since 2024-07-23.
- Refresh tokens are 30 days, so any leftover browser session expired by August 2024.
- No matches for the legacy issuer or JWK kids in CloudWatch over the last 2 weeks.

App clients on the legacy pool:

| Client | Status |
|---|---|
| `CurationAdminTools` | Replaced by the new-pool client in curation-admin-tools#840 (2024-07). |
| `Backstage` | `Pocket/backstage` archived 2024-01; callback domains no longer resolve. |
| `localhost-Prod-PKCE` | Replaced by `localhost-curation-admin-tools` on the new pool (2024-06). |
| `AWSElasticsearch-server-log` | Dead; Elasticsearch no longer used. |

## Deployment steps

- [x] Pre-merge: confirmed no legacy-issuer JWT has reached admin-api in the last 2 weeks.
- [ ] Post-merge: watch Sentry for ~1 week.
- [ ] Follow-up: decommission `CognitoAdmin-Prod` in AWS (separate ticket).

## References

- JIRA: https://mozilla-hub.atlassian.net/browse/HNT-2502
- #150 — dual-pool support introduced
- [curation-admin-tools#840](https://github.com/Pocket/curation-admin-tools/pull/840) — last frontend migration to the new pool
