### PR TITLE
chore: stop logging context missing errors for AWS xray

### DIFF
--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -15,8 +15,10 @@ import {
 import { sentryPlugin } from '@pocket-tools/apollo-utils';
 import { graphqlUploadExpress } from 'graphql-upload';
 
-//Set XRAY to just log if the context is missing instead of a runtime error
-AWSXRay.setContextMissingStrategy('LOG_ERROR');
+// 2026-05-04: Set XRAY to ignore context missing errors
+// AWS logs are flooded with context missing errors, making it difficult to
+// debug other issues.
+AWSXRay.setContextMissingStrategy('IGNORE_ERROR');
 
 //Add the AWS XRAY ECS plugin that will add ecs specific data to the trace
 AWSXRay.config([AWSXRay.plugins.ECSPlugin]);


### PR DESCRIPTION
## Goal

Stop flooding ECS logs with context missing errors. We are doing nothing with these errors, and they are expected in certain circumstances. From [the docs](https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-nodejs-configuration.html#xray-sdk-nodejs-configuration-envvars):

> Errors related to missing segments or subsegments can occur when you attempt to use an instrumented client in startup code that runs when no request is open, or in code that spawns a new thread.

- logs are flooded with context missing errors that are non-actionable
