### PR TITLE
feat: reject all requests without a JWT

### DIFF
--- a/src/jwtUtils.ts
+++ b/src/jwtUtils.ts
@@ -7,7 +7,7 @@ import jwt, {
 import jwksClient from 'jwks-rsa';
 import { AuthenticationError } from 'apollo-server-errors';
 import config from './config';
-import Sentry from '@sentry/node';
+import * as Sentry from '@sentry/node';
 
 /**
  * Properties of the identity property in CognitoUser below

--- a/src/server/context.spec.ts
+++ b/src/server/context.spec.ts
@@ -1,0 +1,56 @@
+import sinon from 'sinon';
+
+import * as jwtUtils from '../jwtUtils';
+import { getAppContext } from './context';
+
+describe('context', () => {
+  describe('getAppContext', () => {
+    beforeAll(() => {
+      // mock JWT validation
+      sinon.stub(jwtUtils, 'validateAndGetAdminAPIUser').resolves({
+        name: 'test name',
+        groups: ['test group'],
+        username: 'testUserName',
+      });
+    });
+
+    afterAll(() => {
+      sinon.restore();
+    });
+
+    it('should return a context if the request has a JWT', async () => {
+      const request = {
+        headers: {
+          authorization: 'Bearer TestJWT',
+        },
+      };
+
+      const publicKeys = {
+        test: 'test',
+      };
+
+      const context = await getAppContext({ req: request }, publicKeys);
+
+      // context should have expected properties set
+      expect(context.token).not.toBeNull();
+      expect(context.forwardHeaders).not.toBeNull();
+    });
+
+    it('should throw if the request does not have a JWT', async () => {
+      const request = {
+        headers: {
+          someNonAuthorizationHeader: 'someValue',
+        },
+      };
+
+      const publicKeys = {
+        test: 'test',
+      };
+
+      // creating context should throw if authorization header is missing
+      await expect(getAppContext({ req: request }, publicKeys)).rejects.toThrow(
+        new Error('Internal server error'),
+      );
+    });
+  });
+});

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -1,9 +1,12 @@
+import * as Sentry from '@sentry/node';
+
 import {
   AdminAPIUser,
   getSigningKeysFromServer,
   validateAndGetAdminAPIUser,
 } from '../jwtUtils';
 import { extractHeader } from './requestHelpers';
+
 export type IContext = {
   publicKeys?: Record<string, string>;
   token?: string;
@@ -18,20 +21,33 @@ export async function getAppContext(
   { req },
   publicKeys: Record<string, string>,
 ): Promise<IContext> {
-  //See if we have an authorization header
+  // See if we have an authorization header
   const token = req.headers.authorization ?? null;
+
+  // if the request doesn't have a JWT, reject it outright
+  if (!token) {
+    // log to ECS
+    console.log('Request is missing JWT');
+    console.log(req);
+
+    Sentry.captureException('Request is missing JWT');
+
+    // throw a generic error if request is missing JWT
+    throw new Error('Internal server error');
+  }
 
   const context: IContext = { token, publicKeys };
 
-  //OH boy! we have an authorization header, lets pull out our JWT and validate it.
-  if (token) {
-    context.token = token.split(' ')[1];
-    //AHH we have a user. Lets put it in our request to use elsewhere.
-    context.adminAPIUser = await validateAndGetAdminAPIUser(
-      context.token,
-      publicKeys,
-    );
-  }
+  // OH boy! we have an authorization header, lets pull out our JWT and validate it.
+  context.token = token.split(' ')[1];
+
+  // AHH we have a user. Lets put it in our request to use elsewhere.
+  // this will throw if the provided JWT is invalid.
+  context.adminAPIUser = await validateAndGetAdminAPIUser(
+    context.token,
+    publicKeys,
+  );
+
   // Add the request headers we want to forward to the subgraphs
   context.forwardHeaders = {
     // We want the originating client, which is the leftmost IP address

--- a/src/server/main.spec.ts
+++ b/src/server/main.spec.ts
@@ -7,9 +7,23 @@ describe('Context factory function', () => {
     const keyStub = sinon.stub(jwtUtils, 'getSigningKeysFromServer').resolves({
       testKID: 'hereisalongkidstring',
     });
-    await contextFactory({ req: { headers: {} } });
-    await contextFactory({ req: { headers: {} } });
-    await contextFactory({ req: { headers: {} } });
+
+    // mock JWT validation
+    sinon.stub(jwtUtils, 'validateAndGetAdminAPIUser').resolves({
+      name: 'test name',
+      groups: ['test group'],
+      username: 'testUserName',
+    });
+
+    await contextFactory({
+      req: { headers: { authorization: 'Bearer TestRawJWT' } },
+    });
+    await contextFactory({
+      req: { headers: { authorization: 'Bearer TestRawJWT' } },
+    });
+    await contextFactory({
+      req: { headers: { authorization: 'Bearer TestRawJWT' } },
+    });
 
     expect(keyStub.callCount).toEqual(1);
 

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -58,7 +58,9 @@ async function startServer() {
     // enable cross-site request forgery protection
     csrfPrevention: true,
   });
+
   await server.start();
+
   return server;
 }
 


### PR DESCRIPTION
## Goal

reject all requests to admin API that do not include a JWT to reduce potential attacks from the wider internet. (the admin API gateway is open to the public due to the curation admin tool.)

- fix sentry import
- update tests

currently deployed to dev.

client testing checklist:
- [x] curation admin tool (prospect API & corpus API)
- [x] prospect lambda
- [x] section manager lambda
- [x] scheduler lambda
- [ ] content ML services (unsure how to test on dev, but [code clearly shows a JWT included in requests](https://github.com/mozilla/content-ml-services/blob/27903ff02f6be4a0488153ffc98bd91be547145c/ml_shared/common/corpus_api/admin_backend.py#L205))

## I'd love feedback/perspectives on:

- any reason we _shouldn't_ enforce a JWT auth header?

## Implementation Decisions:

there isn't too much actually changed here - instead of allowing a missing `token` when creating the app context, we are now requiring it.

even though in practice some of the fields are now required, i didn't update the `IContext` type to keep the changes here small in scope. i can update to do this if we think it's worthwhile.

## References

JIRA ticket:
* [HNT-2548](https://mozilla-hub.atlassian.net/browse/HNT-2548)


[HNT-2548]: https://mozilla-hub.atlassian.net/browse/HNT-2548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ