### PR TITLE
chore: stop sending missing JWT error to sentry

### DIFF
--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -1,5 +1,3 @@
-import * as Sentry from '@sentry/node';
-
 import {
   AdminAPIUser,
   getSigningKeysFromServer,
@@ -30,7 +28,9 @@ export async function getAppContext(
     console.log('Request is missing JWT');
     console.log(req);
 
-    Sentry.captureException('Request is missing JWT');
+    // uncomment below if we ever need sentry reporting on missing JWTs
+    // (ideally this gets handled at a higher level - e.g. cloud metrics)
+    // Sentry.captureException('Request is missing JWT');
 
     // throw a generic error if request is missing JWT
     throw new Error('Internal server error');


### PR DESCRIPTION
## Goal

to reduce noise in our alerts slack channel, stop sending missing JWT errors to sentry.

- non-actionable error at this time, so no reason to be alerted on it

## Implementation Decisions
- continue to log the errors for some level of visibility

## Deployment steps
- [ ] Database migrations?
- [ ] Secrets?
- [ ] **FOR POCKET DEVELOPERS ONLY** - Post in [\#changelog](https://pocket.slack.com/archives/C0Q4UFMDZ):
> Write a #changelog message using our [best practices](https://docs.google.com/document/d/1oEt8Mtkp-6Xz9S2zaNX1EIXfQIEDN2JpY0diuPc1HZc/edit) if this PR (potentially) impacts users. Describe the 'why' and 'what'. @mention relevant teams. Link to this PR.

## References

JIRA ticket:
* [HNT-2988](https://mozilla-hub.atlassian.net/browse/HNT-2988)

[HNT-2988]: https://mozilla-hub.atlassian.net/browse/HNT-2988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ